### PR TITLE
Add proper emoji support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'redcarpet'
 gem 'rouge'
 gem 'omniauth-github'
 gem 'analytics-ruby', require: 'segment'
+gem 'gemoji-parser'
 
 group :development, :test do
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
     ffi (1.9.14)
     font-awesome-rails (4.6.3.1)
       railties (>= 3.2, < 5.1)
+    gemoji (2.1.0)
+    gemoji-parser (1.3.1)
+      gemoji (>= 2.1.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.4)
@@ -212,6 +215,7 @@ DEPENDENCIES
   byebug
   dotenv-rails
   font-awesome-rails
+  gemoji-parser
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)

--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -8,7 +8,7 @@ class MarkdownService
     def paragraph(text)
       emojified = EmojiParser.detokenize(text)
 
-      "<p>#{emojified}</p>"
+      "<p>#{emojified}</p>\n"
     end
 
     def link(link, title, content)

--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -6,9 +6,9 @@ class MarkdownService
     include Rouge::Plugins::Redcarpet
 
     def paragraph(text)
-        emojified = EmojiParser.detokenize(text)
+      emojified = EmojiParser.detokenize(text)
 
-        "<p>#{emojified}</p>"
+      "<p>#{emojified}</p>"
     end
 
     def link(link, title, content)

--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -5,6 +5,12 @@ class MarkdownService
   class Renderer < Redcarpet::Render::HTML
     include Rouge::Plugins::Redcarpet
 
+    def paragraph(text)
+        emojified = EmojiParser.detokenize(text)
+
+        "<p>#{emojified}</p>"
+    end
+
     def link(link, title, content)
       if link.starts_with?("http")
         "<a href=\"#{link}\" title=\"#{title}\" target=\"_blank\" rel=\"noreferrer\">#{content}</a>"

--- a/test/services/markdown_service_test.rb
+++ b/test/services/markdown_service_test.rb
@@ -10,11 +10,11 @@ class MarkdownServiceTest < ActiveSupport::TestCase
   end
 
   test 'it parses emoji' do
-      input = 'Test :see_no_evil: :speak_no_evil: :hear_no_evil'
-      expected = '<p>Test 🙈 🙊 🙉</p>'
-      output = MarkdownService.new.render(input)
+    input = 'Test :see_no_evil: :speak_no_evil: :hear_no_evil'
+    expected = '<p>Test 🙈 🙊 🙉</p>'
+    output = MarkdownService.new.render(input)
 
-      assert_equal(output, expected)
+    assert_equal(output, expected)
   end
 
   test 'it automatically creates links' do

--- a/test/services/markdown_service_test.rb
+++ b/test/services/markdown_service_test.rb
@@ -9,6 +9,14 @@ class MarkdownServiceTest < ActiveSupport::TestCase
     assert_equal(output, expected)
   end
 
+  test 'it parses emoji' do
+      input = 'Test :see_no_evil: :speak_no_evil: :hear_no_evil'
+      expected = '<p>Test 🙈 🙊 🙉</p>'
+      output = MarkdownService.new.render(input)
+
+      assert_equal(output, expected)
+  end
+
   test 'it automatically creates links' do
     input = 'https://example.com'
     expected = "<p><a href=\"https://example.com\" target=\"_blank\" rel=\"noreferrer\">https://example.com</a></p>\n"


### PR DESCRIPTION
This PR adds emoji support to the Markdown renderer, using [gemoji](https://github.com/gmac/gemoji-parser#tokenizing).

I've added one test, but am happy to add more if wanted.

![https://media.giphy.com/media/MUlmRFnTQxwJ2/giphy.gif](https://media.giphy.com/media/MUlmRFnTQxwJ2/giphy.gif)
