### PR TITLE
Add support for project collection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'sprockets-es6'
 gem 'therubyracer', platforms: :ruby
+gem 'active_model_serializers'
 
 gem 'jquery-rails'
 gem 'turbolinks', '~> 5'
-gem 'jbuilder', '~> 2.5'
 
 gem 'bourbon'
 gem 'bootstrap-sass', '~> 3.3.6'

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'octokit'
 
 group :development, :test do
   gem 'dotenv-rails'
+  gem 'webmock'
+  gem 'vcr'
   gem 'byebug', platform: :mri
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,9 @@ gem 'bootstrap-social-rails'
 gem 'redcarpet'
 gem 'rouge'
 gem 'omniauth-github'
+
 gem 'analytics-ruby', require: 'segment'
+gem 'octokit'
 
 group :development, :test do
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
     commander (4.4.0)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     dotenv (2.1.1)
     dotenv-rails (2.1.1)
@@ -80,6 +82,7 @@ GEM
       railties (>= 3.2, < 5.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashdiff (0.3.0)
     hashie (3.4.4)
     highline (1.7.8)
     i18n (0.7.0)
@@ -165,6 +168,7 @@ GEM
     redcarpet (3.3.4)
     ref (2.0.0)
     rouge (2.0.5)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.5)
       railties (>= 4.0.0, < 6)
@@ -203,11 +207,16 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
+    vcr (3.0.3)
     web-console (3.3.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -241,7 +250,9 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  vcr
   web-console
+  webmock
 
 BUNDLED WITH
    1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     analytics-ruby (2.2.2)
       commander (~> 4.4)
     arel (7.0.0)
@@ -117,6 +118,8 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    octokit (4.3.0)
+      sawyer (~> 0.7.0, >= 0.5.3)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
@@ -169,6 +172,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sawyer (0.7.0)
+      addressable (>= 2.3.5, < 2.5)
+      faraday (~> 0.8, < 0.10)
     spring (1.7.2)
     spring-watcher-listen (2.0.0)
       listen (>= 2.7, < 4.0)
@@ -220,6 +226,7 @@ DEPENDENCIES
   font-awesome-rails
   jquery-rails
   listen (~> 3.0.5)
+  octokit
   omniauth-github
   pg (~> 0.18)
   puma (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.10.2)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (~> 0.1.1.beta2)
+      railties (>= 4.1, < 6)
     activejob (5.0.0)
       activesupport (= 5.0.0)
       globalid (>= 0.3.6)
@@ -77,13 +82,13 @@ GEM
     hashie (3.4.4)
     highline (1.7.8)
     i18n (0.7.0)
-    jbuilder (2.5.0)
-      activesupport (>= 3.0.0, < 5.1)
-      multi_json (~> 1.2)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (1.8.3)
+    jsonapi (0.1.1.beta2)
+      json (~> 1.8)
     jwt (1.5.4)
     libv8 (3.16.14.15)
     listen (3.0.8)
@@ -205,6 +210,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   analytics-ruby
   bootstrap-sass (~> 3.3.6)
   bootstrap-social-rails
@@ -212,7 +218,6 @@ DEPENDENCIES
   byebug
   dotenv-rails
   font-awesome-rails
-  jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
   omniauth-github

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -9,18 +9,16 @@ class ProjectsController < ApplicationController
   end
 
   def validate_github_url
-    begin
-      url = params[:url]
+    url = params[:url]
 
-      client = Octokit::Client.new(access_token: current_user.access_token)
-      client.repository(parse_github_url(url))
+    client = Octokit::Client.new(access_token: current_user.access_token)
+    client.repository(parse_github_url(url))
 
-      render json: { valid: true }
-    rescue Octokit::NotFound
-      render json: { valid: false }, status: 404
-    rescue Octokit::InvalidRepository, ArgumentError
-      render json: { valid: false }, status: 422
-    end
+    render json: { valid: true }
+  rescue Octokit::NotFound
+    render json: { valid: false }, status: 404
+  rescue Octokit::InvalidRepository, ArgumentError
+    render json: { valid: false }, status: 422
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -24,7 +24,16 @@ class ProjectsController < ApplicationController
   private
 
   def parse_github_url(url)
-    username, repo = URI(url).path.split("/").last(2)
+    uri = URI(url)
+    segments = uri.path.split("/")
+
+    if uri.host != "github.com"
+      throw ArgumentError
+    elsif segments.length != 3 # [ "", "username", "repo" ]
+      throw ArgumentError
+    end
+
+    username, repo = segments.last(2)
     [username, repo].join("/")
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,19 @@
+class ProjectsController < ApplicationController
+  def create
+    project = current_user.projects.build(project_params)
+    if project.save
+      render json: project
+    else
+      render json: { errors: project.errors.full_messages }, status: 422
+    end
+  end
+
+  def validate_github_url
+  end
+
+  private
+
+  def project_params
+    params.permit(:name, :live_url)
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -9,9 +9,24 @@ class ProjectsController < ApplicationController
   end
 
   def validate_github_url
+    begin
+      url = params[:url]
+
+      client = Octokit::Client.new(access_token: current_user.access_token)
+      repo = client.repository(parse_github_url(url))
+
+      render json: { valid: true }
+    rescue Octokit::InvalidRepository, Octokit::NotFound, ArgumentError
+      render json: { valid: false }, status: 422
+    end
   end
 
   private
+
+  def parse_github_url(url)
+    username, repo = URI(url).path.split('/').last(2)
+    [username, repo].join('/')
+  end
 
   def project_params
     params.permit(:name, :live_url)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -28,7 +28,7 @@ class ProjectsController < ApplicationController
     segments = uri.path.split("/")
 
     # Add a schema if one isn't already there
-    if !uri.scheme
+    unless uri.scheme
       uri = URI("https://#{url}")
     end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,7 +16,9 @@ class ProjectsController < ApplicationController
       repo = client.repository(parse_github_url(url))
 
       render json: { valid: true }
-    rescue Octokit::InvalidRepository, Octokit::NotFound, ArgumentError
+    rescue Octokit::NotFound
+      render json: { valid: false }, status: 404
+    rescue Octokit::InvalidRepository, ArgumentError
       render json: { valid: false }, status: 422
     end
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -27,6 +27,12 @@ class ProjectsController < ApplicationController
     uri = URI(url)
     segments = uri.path.split("/")
 
+    # Add a schema if one isn't already there
+    if !uri.scheme
+      uri = URI("https://#{url}")
+    end
+
+    # Make sure everything is kosher
     if uri.host != "github.com"
       throw ArgumentError
     elsif segments.length != 3 # [ "", "username", "repo" ]

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -13,7 +13,7 @@ class ProjectsController < ApplicationController
       url = params[:url]
 
       client = Octokit::Client.new(access_token: current_user.access_token)
-      repo = client.repository(parse_github_url(url))
+      client.repository(parse_github_url(url))
 
       render json: { valid: true }
     rescue Octokit::NotFound
@@ -26,8 +26,8 @@ class ProjectsController < ApplicationController
   private
 
   def parse_github_url(url)
-    username, repo = URI(url).path.split('/').last(2)
-    [username, repo].join('/')
+    username, repo = URI(url).path.split("/").last(2)
+    [username, repo].join("/")
   end
 
   def project_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,10 +7,12 @@ class SessionsController < ApplicationController
     ) || User.create_with_omniauth(auth)
 
     # Update user with latest info from GitHub
-    auth_info_params = ActionController::Parameters.new(auth)
-                  .require(:info)
-                  .permit(:name, :email)
-    user.assign_attributes(auth_info_params)
+    new_attributes = {
+      name: auth[:info][:name],
+      email: auth[:info][:email],
+      access_token: auth[:credentials][:token]
+    }
+    user.assign_attributes(new_attributes)
     user.save if user.changed?
 
     sign_in user

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,5 +2,5 @@ class Project < ApplicationRecord
   belongs_to :user
 
   validates_presence_of :name
-  validates :live_url, format: { with: URI.regexp }, if: 'live_url.present?'
+  validates :live_url, format: { with: URI.regexp }, if: "live_url.present?"
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,6 @@
+class Project < ApplicationRecord
+  belongs_to :user
+
+  validates_presence_of :name
+  validates :live_url, format: { with: URI.regexp }, if: 'live_url.present?'
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,10 +3,11 @@ class User < ApplicationRecord
 
   def self.create_with_omniauth(auth)
     create! do |user|
-      user.provider = auth[:provider]
-      user.uid      = auth[:uid]
-      user.name     = auth[:info][:name]
-      user.email    = auth[:info][:email]
+      user.provider     = auth[:provider]
+      user.uid          = auth[:uid]
+      user.name         = auth[:info][:name]
+      user.email        = auth[:info][:email]
+      user.access_token = auth[:credentials][:token]
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :projects
 
-  validates_presence_of :access_token
+  validates_presence_of :uid, :provider, :access_token
 
   def self.create_with_omniauth(auth)
     create! do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :projects
+
   def self.create_with_omniauth(auth)
     create! do |user|
       user.provider = auth[:provider]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :projects
 
+  validates_presence_of :access_token
+
   def self.create_with_omniauth(auth)
     create! do |user|
       user.provider     = auth[:provider]

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,0 +1,3 @@
+class ProjectSerializer < ActiveModel::Serializer
+  attributes :id, :name, :live_url
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,8 @@ Rails.application.routes.draw do
   get '/', to: 'workshops#index'
   get '/:workshop/', to: 'workshops#render_workshop'
   get '/:workshop/*file', to: 'workshops#render_file', constraints: { file: /.*/ }
+
+  resources :projects, only: :create do
+    get 'validate_github_url', on: :collection
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get '/sign_out', to: 'sessions#destroy'
 
   resources :projects, only: :create do
-    get 'validate_github_url', on: :collection
+    get "validate_github_url", on: :collection
   end
 
   get '/', to: 'workshops#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,11 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/sign_out', to: 'sessions#destroy'
 
-  get '/', to: 'workshops#index'
-  get '/:workshop/', to: 'workshops#render_workshop'
-  get '/:workshop/*file', to: 'workshops#render_file', constraints: { file: /.*/ }
-
   resources :projects, only: :create do
     get 'validate_github_url', on: :collection
   end
+
+  get '/', to: 'workshops#index'
+  get '/:workshop/', to: 'workshops#render_workshop'
+  get '/:workshop/*file', to: 'workshops#render_file', constraints: { file: /.*/ }
 end

--- a/db/migrate/20160815010306_create_projects.rb
+++ b/db/migrate/20160815010306_create_projects.rb
@@ -1,0 +1,11 @@
+class CreateProjects < ActiveRecord::Migration[5.0]
+  def change
+    create_table :projects do |t|
+      t.references :user, foreign_key: true
+      t.string :name
+      t.string :live_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160815203035_add_access_token_to_users.rb
+++ b/db/migrate/20160815203035_add_access_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddAccessTokenToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :access_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160815010306) do
+ActiveRecord::Schema.define(version: 20160815203035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,9 +28,10 @@ ActiveRecord::Schema.define(version: 20160815010306) do
     t.string   "provider"
     t.string   "uid"
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
     t.string   "email"
+    t.string   "access_token"
   end
 
   add_foreign_key "projects", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160813084717) do
+ActiveRecord::Schema.define(version: 20160815010306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "projects", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "name"
+    t.string   "live_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_projects_on_user_id", using: :btree
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "provider"
@@ -24,4 +33,5 @@ ActiveRecord::Schema.define(version: 20160813084717) do
     t.string   "email"
   end
 
+  add_foreign_key "projects", "users"
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -86,5 +86,27 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
         assert_response 404
       end
     end
+
+    test "with invalid host" do
+      get "/projects/validate_github_url",
+          params: {
+            url: "https://wrongwebsite.com/hackclub/hackclub"
+          },
+          xhr: true
+
+      assert_equal "application/json", @response.content_type
+      assert_response 422
+    end
+
+    test "with invalid path to repo" do
+      get "/projects/validate_github_url",
+          params: {
+            url: "https://github.com/wrong/hackclub/hackclub"
+          },
+          xhr: true
+
+      assert_equal "application/json", @response.content_type
+      assert_response 422
+    end
   end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class ProjectsControllerTest < ActionDispatch::IntegrationTest
+  test 'project creation with valid info' do
+    get '/auth/github/callback'
+
+    assert_difference('Project.count') do
+      post '/projects', params: {
+             name: 'Personal Website',
+             live_url: 'https://prophetorpheus.github.io'
+           },
+           xhr: true,
+           as: :json
+    end
+
+    assert_equal 'application/json', @response.content_type
+    assert_response 200, @response.status
+
+    parsed_response = JSON.parse(@response.body)
+
+    assert parsed_response['id']
+    assert_equal parsed_response['name'], 'Personal Website'
+    assert_equal parsed_response['live_url'], 'https://prophetorpheus.github.io'
+  end
+
+  test 'project creation with invalid info' do
+    get '/auth/github/callback'
+
+    post '/projects', params: {}, xhr: true, as: :json
+
+    assert_equal 'application/json', @response.content_type
+    assert_response 422, @response.status
+
+    assert_equal "Name can't be blank", JSON.parse(@response.body)['errors'].first
+  end
+
+  test 'GitHub URL validation' do
+  end
+end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -64,6 +64,20 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    test "with valid repo, but no protocol" do
+      VCR.use_cassette "validate_github_url/valid_repo",
+                       match_requests_on: [:method, :uri] do
+        get "/projects/validate_github_url",
+            params: {
+              url: "github.com/hackclub/hackclub"
+            },
+            xhr: true
+
+        assert_equal "application/json", @response.content_type
+        assert_response 200
+      end
+    end
+
     test "with invalid url" do
       get "/projects/validate_github_url",
           params: {},

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -1,38 +1,38 @@
-require 'test_helper'
+require "test_helper"
 
 class ProjectsControllerTest < ActionDispatch::IntegrationTest
   class CreateTest < ProjectsControllerTest
-    test 'with valid info' do
-      get '/auth/github/callback'
+    test "with valid info" do
+      get "/auth/github/callback"
 
-      assert_difference('Project.count') do
-        post '/projects', params: {
-               name: 'Personal Website',
-               live_url: 'https://prophetorpheus.github.io'
+      assert_difference("Project.count") do
+        post "/projects", params: {
+               name: "Personal Website",
+               live_url: "https://prophetorpheus.github.io"
              },
              xhr: true,
              as: :json
       end
 
-      assert_equal 'application/json', @response.content_type
+      assert_equal "application/json", @response.content_type
       assert_response 200, @response.status
 
       parsed_response = JSON.parse(@response.body)
 
-      assert parsed_response['id']
-      assert_equal parsed_response['name'], 'Personal Website'
-      assert_equal parsed_response['live_url'], 'https://prophetorpheus.github.io'
+      assert parsed_response["id"]
+      assert_equal parsed_response["name"], "Personal Website"
+      assert_equal parsed_response["live_url"], "https://prophetorpheus.github.io"
     end
 
-    test 'with invalid info' do
-      get '/auth/github/callback'
+    test "with invalid info" do
+      get "/auth/github/callback"
 
-      post '/projects', params: {}, xhr: true, as: :json
+      post "/projects", params: {}, xhr: true, as: :json
 
-      assert_equal 'application/json', @response.content_type
+      assert_equal "application/json", @response.content_type
       assert_response 422
 
-      assert_equal "Name can't be blank", JSON.parse(@response.body)['errors'].first
+      assert_equal "Name can't be blank", JSON.parse(@response.body)["errors"].first
     end
   end
 
@@ -40,18 +40,18 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     def setup
       super
 
-      get '/auth/github/callback'
+      get "/auth/github/callback"
     end
 
-    test 'with valid url repo' do
-      VCR.use_cassette 'validate_github_url/valid_repo', match_requests_on: [ :method, :uri ] do
-        get '/projects/validate_github_url',
+    test "with valid url repo" do
+      VCR.use_cassette "validate_github_url/valid_repo", match_requests_on: [ :method, :uri ] do
+        get "/projects/validate_github_url",
             params: {
-              url: 'https://github.com/hackclub/hackclub'
+              url: "https://github.com/hackclub/hackclub"
             },
             xhr: true
 
-        assert_equal 'application/json', @response.content_type
+        assert_equal "application/json", @response.content_type
         assert_response 200
       end
     end
@@ -61,20 +61,20 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
           params: {},
           xhr: true
 
-      assert_equal 'application/json', @response.content_type
+      assert_equal "application/json", @response.content_type
       assert_response 422
     end
 
     test "with repo that doesn't exist" do
-      VCR.use_cassette 'validate_github_url/nonexistant_repo',
+      VCR.use_cassette "validate_github_url/nonexistant_repo",
                        match_requests_on: [ :method, :uri ] do
-        get '/projects/validate_github_url',
+        get "/projects/validate_github_url",
             params: {
               url: "https://github.com/this_repository/does_not_exist"
             },
             xhr: true
 
-        assert_equal 'application/json', @response.content_type
+        assert_equal "application/json", @response.content_type
         assert_response 404
       end
     end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -6,7 +6,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       get "/auth/github/callback"
 
       assert_difference("Project.count") do
-        post "/projects", params: {
+        post "/projects",
+             params: {
                name: "Personal Website",
                live_url: "https://prophetorpheus.github.io"
              },
@@ -21,7 +22,10 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
       assert parsed_response["id"]
       assert_equal parsed_response["name"], "Personal Website"
-      assert_equal parsed_response["live_url"], "https://prophetorpheus.github.io"
+      assert_equal(
+        parsed_response["live_url"],
+        "https://prophetorpheus.github.io"
+      )
     end
 
     test "with invalid info" do
@@ -32,7 +36,10 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       assert_equal "application/json", @response.content_type
       assert_response 422
 
-      assert_equal "Name can't be blank", JSON.parse(@response.body)["errors"].first
+      assert_equal(
+        "Name can't be blank",
+        JSON.parse(@response.body)["errors"].first
+      )
     end
   end
 
@@ -44,7 +51,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test "with valid url repo" do
-      VCR.use_cassette "validate_github_url/valid_repo", match_requests_on: [ :method, :uri ] do
+      VCR.use_cassette "validate_github_url/valid_repo",
+                       match_requests_on: [:method, :uri] do
         get "/projects/validate_github_url",
             params: {
               url: "https://github.com/hackclub/hackclub"
@@ -67,7 +75,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
     test "with repo that doesn't exist" do
       VCR.use_cassette "validate_github_url/nonexistant_repo",
-                       match_requests_on: [ :method, :uri ] do
+                       match_requests_on: [:method, :uri] do
         get "/projects/validate_github_url",
             params: {
               url: "https://github.com/this_repository/does_not_exist"

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -43,20 +43,21 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       get '/auth/github/callback'
     end
 
-    test 'with valid url' do
-      get '/projects/validate_github_url',
-          params: {
-            url: 'https://github.com/hackclub/hackclub'
-          },
-          xhr: true,
-          as: :json
+    test 'with valid url repo' do
+      VCR.use_cassette 'validate_github_url/valid_repo', match_requests_on: [ :method, :uri ] do
+        get '/projects/validate_github_url',
+            params: {
+              url: 'https://github.com/hackclub/hackclub'
+            },
+            xhr: true
 
-      assert_equal 'application/json', @response.content_type
-      assert_response 200
+        assert_equal 'application/json', @response.content_type
+        assert_response 200
+      end
     end
 
-    test 'with invalid url' do
-      get '/projects/validate_github_url',
+    test "with invalid url" do
+      get "/projects/validate_github_url",
           params: {},
           xhr: true
 
@@ -65,14 +66,17 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test "with repo that doesn't exist" do
-      get '/projects/validate_github_url',
-          params: {
-            url: "https://github.com/#{SecureRandom.hex}_this_repository/does_not_exist"
-          },
-          xhr: true
+      VCR.use_cassette 'validate_github_url/nonexistant_repo',
+                       match_requests_on: [ :method, :uri ] do
+        get '/projects/validate_github_url',
+            params: {
+              url: "https://github.com/this_repository/does_not_exist"
+            },
+            xhr: true
 
-      assert_equal 'application/json', @response.content_type
-      assert_response 404
+        assert_equal 'application/json', @response.content_type
+        assert_response 404
+      end
     end
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -31,12 +31,14 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   test 'updates user details on login' do
     NEW_NAME = 'Mr. Robot'
     NEW_EMAIL = 'different@hackclub.com'
+    NEW_ACCESS_TOKEN = 'test'
 
     # FYI: @mock_auth is declared in test_helper.rb and is used as the auth hash
     # when using OmniAuth in tests. This verified that our new values aren't
     # already in the auth hash.
     assert_not_equal @mock_auth[:info][:name], NEW_NAME
     assert_not_equal @mock_auth[:info][:email], NEW_EMAIL
+    assert_not_equal @mock_auth[:credentials][:token], NEW_ACCESS_TOKEN
 
     # Confirm that the user created with the default auth hash doesn't match our
     # new values
@@ -45,6 +47,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_not_equal old_user.name, NEW_NAME
     assert_not_equal old_user.email, NEW_EMAIL
+    assert_not_equal old_user.access_token, NEW_ACCESS_TOKEN
 
     sign_out
 
@@ -56,6 +59,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal NEW_NAME, updated_user.name
     assert_equal @mock_auth[:info][:email], updated_user.email # Email hasn't changed yet
+    assert_equal @mock_auth[:credentials][:token], updated_user.access_token # Token hasn't changed
 
     sign_out
 
@@ -67,6 +71,17 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal NEW_NAME, updated_user.name
     assert_equal NEW_EMAIL, updated_user.email
+    assert_equal @mock_auth[:credentials][:token], updated_user.access_token # Token hasn't changed yet
+
+    # Finally, for the access token
+    @mock_auth[:credentials][:token] = NEW_ACCESS_TOKEN
+
+    get '/auth/github/callback'
+    updated_user = User.last
+
+    assert_equal NEW_NAME, updated_user.name
+    assert_equal NEW_EMAIL, updated_user.email
+    assert_equal NEW_ACCESS_TOKEN, updated_user.access_token
   end
 
   test 'tracks sign in in analytics' do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -76,7 +76,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     # Finally, for the access token
     @mock_auth[:credentials][:token] = NEW_ACCESS_TOKEN
 
-    get '/auth/github/callback'
+    get "/auth/github/callback"
     updated_user = User.last
 
     assert_equal NEW_NAME, updated_user.name

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -31,7 +31,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   test 'updates user details on login' do
     NEW_NAME = 'Mr. Robot'
     NEW_EMAIL = 'different@hackclub.com'
-    NEW_ACCESS_TOKEN = 'test'
+    NEW_ACCESS_TOKEN = "test".freeze
 
     # FYI: @mock_auth is declared in test_helper.rb and is used as the auth hash
     # when using OmniAuth in tests. This verified that our new values aren't
@@ -59,7 +59,10 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal NEW_NAME, updated_user.name
     assert_equal @mock_auth[:info][:email], updated_user.email # Email hasn't changed yet
-    assert_equal @mock_auth[:credentials][:token], updated_user.access_token # Token hasn't changed
+    assert_equal(
+      @mock_auth[:credentials][:token],
+      updated_user.access_token
+    ) # Token hasn't changed
 
     sign_out
 
@@ -71,7 +74,10 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal NEW_NAME, updated_user.name
     assert_equal NEW_EMAIL, updated_user.email
-    assert_equal @mock_auth[:credentials][:token], updated_user.access_token # Token hasn't changed yet
+    assert_equal(
+      @mock_auth[:credentials][:token],
+      updated_user.access_token
+    ) # Token hasn't changed yet
 
     # Finally, for the access token
     @mock_auth[:credentials][:token] = NEW_ACCESS_TOKEN

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -1,0 +1,4 @@
+personal_website:
+  user: basic
+  name: Personal Website
+  live_url: https://prophetorpheus.github.io

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,3 +2,5 @@ basic:
   provider: github
   uid: 1337
   name: Example User
+  email: example@example.com
+  access_token: <%= SecureRandom.hex(32) %>

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ProjectTest < ActiveSupport::TestCase
   def setup
@@ -6,7 +6,7 @@ class ProjectTest < ActiveSupport::TestCase
     super
   end
 
-  test 'expected attributes are available' do
+  test "expected attributes are available" do
     expected_attributes = [
       :user,
       :name,
@@ -18,7 +18,7 @@ class ProjectTest < ActiveSupport::TestCase
     end
   end
 
-  test 'expected attributes are required' do
+  test "expected attributes are required" do
     required_attributes = [
       :user,
       :name
@@ -28,21 +28,24 @@ class ProjectTest < ActiveSupport::TestCase
       original_value = @project.public_send(a)
       @project.public_send("#{a}=", nil)
 
-      assert_not @project.valid?, "Expected project to be invalid when #{a} isn't set"
+      assert_not(
+        @project.valid?,
+        "Expected project to be invalid when #{a} isn't set"
+      )
 
       @project.public_send("#{a}=", original_value)
     end
   end
 
-  test 'live_url must be a valid url' do
-    @project.live_url = 'this is not a url'
+  test "live_url must be a valid url" do
+    @project.live_url = "this is not a url"
     assert_not @project.valid?
 
-    @project.live_url = 'https://example.com'
+    @project.live_url = "https://example.com"
     assert @project.valid?
   end
 
-  test 'live_url must be able to be nil' do
+  test "live_url must be able to be nil" do
     @project.live_url = nil
     assert @project.valid?
   end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class ProjectTest < ActiveSupport::TestCase
+  def setup
+    @project = projects(:personal_website)
+    super
+  end
+
+  test 'expected attributes are available' do
+    expected_attributes = [
+      :user,
+      :name,
+      :live_url
+    ]
+
+    expected_attributes.each do |a|
+      assert @project.respond_to?(a), "Expected project to respond to #{a}"
+    end
+  end
+
+  test 'expected attributes are required' do
+    required_attributes = [
+      :user,
+      :name
+    ]
+
+    required_attributes.each do |a|
+      original_value = @project.public_send(a)
+      @project.public_send("#{a}=", nil)
+
+      assert_not @project.valid?, "Expected project to be invalid when #{a} isn't set"
+
+      @project.public_send("#{a}=", original_value)
+    end
+  end
+
+  test 'live_url must be a valid url' do
+    @project.live_url = 'this is not a url'
+    assert_not @project.valid?
+
+    @project.live_url = 'https://example.com'
+    assert @project.valid?
+  end
+
+  test 'live_url must be able to be nil' do
+    @project.live_url = nil
+    assert @project.valid?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+  def setup
+    @user = users(:basic)
+    super
+  end
   test 'successfully creates with omniauth' do
     auth = @mock_auth
     orig_count = User.count
@@ -12,5 +16,11 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(auth[:provider], user.provider)
     assert_equal(auth[:uid], user.uid)
     assert_equal(auth[:info][:name], user.name)
+  end
+
+  test 'has many projects' do
+    assert_difference '@user.projects.count' do
+      @user.projects.create(name: 'Test')
+    end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -6,6 +6,29 @@ class UserTest < ActiveSupport::TestCase
     super
   end
 
+  class AttributesTest < UserTest
+    test 'has many projects' do
+      assert_difference '@user.projects.count' do
+        @user.projects.create(name: 'Test')
+      end
+    end
+
+    test 'uid is required' do
+      @user.uid = nil
+      assert_not @user.valid?
+    end
+
+    test 'provider is required' do
+      @user.provider = nil
+      assert_not @user.valid?
+    end
+
+    test 'access token is required' do
+      @user.access_token = nil
+      assert_not @user.valid?
+    end
+  end
+
   test 'successfully creates with omniauth' do
     auth = @mock_auth
     orig_count = User.count
@@ -18,16 +41,5 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(auth[:uid], user.uid)
     assert_equal(auth[:info][:name], user.name)
     assert_equal(auth[:credentials][:token], user.access_token)
-  end
-
-  test 'has many projects' do
-    assert_difference '@user.projects.count' do
-      @user.projects.create(name: 'Test')
-    end
-  end
-
-  test 'access token is required' do
-    @user.access_token = nil
-    assert_not @user.valid?
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -25,4 +25,9 @@ class UserTest < ActiveSupport::TestCase
       @user.projects.create(name: 'Test')
     end
   end
+
+  test 'access token is required' do
+    @user.access_token = nil
+    assert_not @user.valid?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,6 +5,7 @@ class UserTest < ActiveSupport::TestCase
     @user = users(:basic)
     super
   end
+
   test 'successfully creates with omniauth' do
     auth = @mock_auth
     orig_count = User.count
@@ -16,6 +17,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(auth[:provider], user.provider)
     assert_equal(auth[:uid], user.uid)
     assert_equal(auth[:info][:name], user.name)
+    assert_equal(auth[:credentials][:token], user.access_token)
   end
 
   test 'has many projects' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,23 +7,23 @@ class UserTest < ActiveSupport::TestCase
   end
 
   class AttributesTest < UserTest
-    test 'has many projects' do
-      assert_difference '@user.projects.count' do
-        @user.projects.create(name: 'Test')
+    test "has many projects" do
+      assert_difference "@user.projects.count" do
+        @user.projects.create(name: "Test")
       end
     end
 
-    test 'uid is required' do
+    test "uid is required" do
       @user.uid = nil
       assert_not @user.valid?
     end
 
-    test 'provider is required' do
+    test "provider is required" do
       @user.provider = nil
       assert_not @user.valid?
     end
 
-    test 'access token is required' do
+    test "access token is required" do
       @user.access_token = nil
       assert_not @user.valid?
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 VCR.configure do |config|
-  config.cassette_library_dir = Rails.root.join('test', 'vcr', 'cassettes')
+  config.cassette_library_dir = Rails.root.join("test", "vcr", "cassettes")
   config.hook_into :webmock
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,9 @@ class ActiveSupport::TestCase
         info: {
           name: 'Prophet Orpheus',
           email: 'prophetorpheus@hackclub.com'
+        },
+        credentials: {
+          token: SecureRandom.hex
         }
       }
     )

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,11 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
+VCR.configure do |config|
+  config.cassette_library_dir = Rails.root.join('test', 'vcr', 'cassettes')
+  config.hook_into :webmock
+end
+
 class ActiveSupport::TestCase
   include SessionsHelper
 

--- a/test/vcr/cassettes/validate_github_url/nonexistant_repo.yml
+++ b/test/vcr/cassettes/validate_github_url/nonexistant_repo.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/this_repository/does_not_exist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.3.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 16 Aug 2016 20:53:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 404 Not Found
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '54'
+      X-Ratelimit-Reset:
+      - '1471382126'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Github-Request-Id:
+      - 43B4C7A7:2CFA5:F6E6B6:57B37D63
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}'
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 20:53:55 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr/cassettes/validate_github_url/valid_repo.yml
+++ b/test/vcr/cassettes/validate_github_url/valid_repo.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/hackclub/hackclub
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.3.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 16 Aug 2016 20:53:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '53'
+      X-Ratelimit-Reset:
+      - '1471382126'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      - Accept-Encoding
+      Etag:
+      - W/"d367e7ac7a59f3d177c6f8103df72e33"
+      Last-Modified:
+      - Tue, 16 Aug 2016 16:22:28 GMT
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - 7f48e2f7761567e923121f17538d7a6d
+      X-Github-Request-Id:
+      - 43B4C7A7:2CFA2:EE721F:57B37D63
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":33744138,"name":"hackclub","full_name":"hackclub/hackclub","owner":{"login":"hackclub","id":5633654,"avatar_url":"https://avatars.githubusercontent.com/u/5633654?v=3","gravatar_id":"","url":"https://api.github.com/users/hackclub","html_url":"https://github.com/hackclub","followers_url":"https://api.github.com/users/hackclub/followers","following_url":"https://api.github.com/users/hackclub/following{/other_user}","gists_url":"https://api.github.com/users/hackclub/gists{/gist_id}","starred_url":"https://api.github.com/users/hackclub/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/hackclub/subscriptions","organizations_url":"https://api.github.com/users/hackclub/orgs","repos_url":"https://api.github.com/users/hackclub/repos","events_url":"https://api.github.com/users/hackclub/events{/privacy}","received_events_url":"https://api.github.com/users/hackclub/received_events","type":"Organization","site_admin":false},"private":false,"html_url":"https://github.com/hackclub/hackclub","description":"Hack
+        Club is the worldwide movement of free student-led coding clubs","fork":false,"url":"https://api.github.com/repos/hackclub/hackclub","forks_url":"https://api.github.com/repos/hackclub/hackclub/forks","keys_url":"https://api.github.com/repos/hackclub/hackclub/keys{/key_id}","collaborators_url":"https://api.github.com/repos/hackclub/hackclub/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/hackclub/hackclub/teams","hooks_url":"https://api.github.com/repos/hackclub/hackclub/hooks","issue_events_url":"https://api.github.com/repos/hackclub/hackclub/issues/events{/number}","events_url":"https://api.github.com/repos/hackclub/hackclub/events","assignees_url":"https://api.github.com/repos/hackclub/hackclub/assignees{/user}","branches_url":"https://api.github.com/repos/hackclub/hackclub/branches{/branch}","tags_url":"https://api.github.com/repos/hackclub/hackclub/tags","blobs_url":"https://api.github.com/repos/hackclub/hackclub/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/hackclub/hackclub/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/hackclub/hackclub/git/refs{/sha}","trees_url":"https://api.github.com/repos/hackclub/hackclub/git/trees{/sha}","statuses_url":"https://api.github.com/repos/hackclub/hackclub/statuses/{sha}","languages_url":"https://api.github.com/repos/hackclub/hackclub/languages","stargazers_url":"https://api.github.com/repos/hackclub/hackclub/stargazers","contributors_url":"https://api.github.com/repos/hackclub/hackclub/contributors","subscribers_url":"https://api.github.com/repos/hackclub/hackclub/subscribers","subscription_url":"https://api.github.com/repos/hackclub/hackclub/subscription","commits_url":"https://api.github.com/repos/hackclub/hackclub/commits{/sha}","git_commits_url":"https://api.github.com/repos/hackclub/hackclub/git/commits{/sha}","comments_url":"https://api.github.com/repos/hackclub/hackclub/comments{/number}","issue_comment_url":"https://api.github.com/repos/hackclub/hackclub/issues/comments{/number}","contents_url":"https://api.github.com/repos/hackclub/hackclub/contents/{+path}","compare_url":"https://api.github.com/repos/hackclub/hackclub/compare/{base}...{head}","merges_url":"https://api.github.com/repos/hackclub/hackclub/merges","archive_url":"https://api.github.com/repos/hackclub/hackclub/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/hackclub/hackclub/downloads","issues_url":"https://api.github.com/repos/hackclub/hackclub/issues{/number}","pulls_url":"https://api.github.com/repos/hackclub/hackclub/pulls{/number}","milestones_url":"https://api.github.com/repos/hackclub/hackclub/milestones{/number}","notifications_url":"https://api.github.com/repos/hackclub/hackclub/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/hackclub/hackclub/labels{/name}","releases_url":"https://api.github.com/repos/hackclub/hackclub/releases{/id}","deployments_url":"https://api.github.com/repos/hackclub/hackclub/deployments","created_at":"2015-04-10T18:28:39Z","updated_at":"2016-08-16T16:22:28Z","pushed_at":"2016-08-16T19:21:37Z","git_url":"git://github.com/hackclub/hackclub.git","ssh_url":"git@github.com:hackclub/hackclub.git","clone_url":"https://github.com/hackclub/hackclub.git","svn_url":"https://github.com/hackclub/hackclub","homepage":"https://hackclub.com","size":350734,"stargazers_count":230,"watchers_count":230,"language":"JavaScript","has_issues":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":90,"mirror_url":null,"open_issues_count":9,"forks":90,"open_issues":9,"watchers":230,"default_branch":"master","organization":{"login":"hackclub","id":5633654,"avatar_url":"https://avatars.githubusercontent.com/u/5633654?v=3","gravatar_id":"","url":"https://api.github.com/users/hackclub","html_url":"https://github.com/hackclub","followers_url":"https://api.github.com/users/hackclub/followers","following_url":"https://api.github.com/users/hackclub/following{/other_user}","gists_url":"https://api.github.com/users/hackclub/gists{/gist_id}","starred_url":"https://api.github.com/users/hackclub/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/hackclub/subscriptions","organizations_url":"https://api.github.com/users/hackclub/orgs","repos_url":"https://api.github.com/users/hackclub/repos","events_url":"https://api.github.com/users/hackclub/events{/privacy}","received_events_url":"https://api.github.com/users/hackclub/received_events","type":"Organization","site_admin":false},"network_count":90,"subscribers_count":24}'
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 20:53:55 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This pull request tracks additions to add support for project collection. Right now only the backend is implemented, @MaxWofford needs to push the frontend implementation to this branch.

Quick notes about this:
- This PR adds a required `access_token` field to users. When being deployed to production, all sessions will need to be invalidated so this is recorded when users re-login.
