### PR TITLE
Render Markdown in sidebar (the TOC)

### DIFF
--- a/app/assets/stylesheets/workshops.scss
+++ b/app/assets/stylesheets/workshops.scss
@@ -10,9 +10,14 @@
   padding-left: 20px;
   margin-top: 20px;
   margin-bottom: 20px;
+
+  // Remove margin from p tags in links (created by Markdown renderer)
+  p {
+    margin: 0;
+  }
 }
 
-/* All links */
+// All links
 .workshop-sidebar .nav > li > a {
   color: #999;
   border-left: 2px solid transparent;
@@ -21,7 +26,7 @@
   font-weight: 400;
 }
 
-/* Nested links */
+// Nested links
 .workshop-sidebar .nav .nav > li > a {
   padding-top: 1px;
   padding-bottom: 1px;
@@ -29,7 +34,7 @@
   font-size: 12px;
 }
 
-/* Active & hover links */
+// Active & hover links
 .workshop-sidebar .nav > .active > a,
 .workshop-sidebar .nav > li > a:hover,
 .workshop-sidebar .nav > li > a:focus {
@@ -39,31 +44,26 @@
   border-left-color: #563d7c;
 }
 
-/* All active links */
+// All active links
 .workshop-sidebar .nav > .active > a,
 .workshop-sidebar .nav > .active:hover > a,
 .workshop-sidebar .nav > .active:focus > a {
   font-weight: 700;
 }
 
-/* Nested active links */
+// Nested active links
 .workshop-sidebar .nav .nav> .active > a,
 .workshop-sidebar .nav .nav> .active:hover > a,
 .workshop-sidebar .nav .nav> .active:focus > a {
   font-weight: 500;
 }
 
-/* Hide inactive nested list */
+// Hide inactive nested list
 .workshop-sidebar .nav ul.nav {
   display: none;
 }
 
-/* Show active nested list */
+// Show active nested list
 .workshop-sidebar .nav > .active > ul.nav {
   display: block;
-}
-
-/* Remove margin from p tags in links (created by Markdown renderer) */
-.workshop-sidebar .nav p {
-  margin: 0;
 }

--- a/app/assets/stylesheets/workshops.scss
+++ b/app/assets/stylesheets/workshops.scss
@@ -62,3 +62,8 @@
 .workshop-sidebar .nav > .active > ul.nav {
   display: block;
 }
+
+/* Remove margin from p tags in links (created by Markdown renderer) */
+.workshop-sidebar .nav p {
+  margin: 0;
+}

--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -87,8 +87,8 @@ class MarkdownService
         elsif in_section
           if level == child_level
             if !section_has_children
-              html += %Q(      <ul class="nav nav-stacked">\n) +
-                      %Q(        <li>#{nav_link text}</li>\n)
+              html += %(      <ul class="nav nav-stacked">\n) +
+                      %(        <li>#{nav_link text}</li>\n)
               section_has_children = true
             else
               html += "        <li>#{nav_link text}</li>\n"

--- a/test/services/markdown_service_test.rb
+++ b/test/services/markdown_service_test.rb
@@ -80,6 +80,7 @@ console.log('test');
     assert_equal(expected, output)
   end
 
+  # rubocop:disable Metrics/LineLength, Style/StringLiterals
   test 'it renders sidebars' do
     # Complete example where the last header has children
     input1 = %Q(
@@ -174,4 +175,5 @@ console.log('test');
     actual = MarkdownService.new.render_sidebar(input)
     assert_equal(expected, actual)
   end
+  # rubocop:enable Metrics/LineLength, Style/StringLiterals
 end

--- a/test/services/markdown_service_test.rb
+++ b/test/services/markdown_service_test.rb
@@ -101,19 +101,19 @@ console.log('test');
 <nav class="workshop-sidebar hidden-print hidden-xs hidden-sm affix">
   <ul id="sidebar" class="nav nav-stacked fixed">
     <li>
-      <a href="#dolor-sit-amet">Dolor Sit Amet</a>
+      <a href="#dolor-sit-amet"><p>Dolor Sit Amet</p></a>
       <ul class="nav nav-stacked">
-        <li><a href="#consectetur-adipiscing-elit">Consectetur Adipiscing Elit</a></li>
-        <li><a href="#morbi-eu-congue">Morbi Eu Congue</a></li>
+        <li><a href="#consectetur-adipiscing-elit"><p>Consectetur Adipiscing Elit</p></a></li>
+        <li><a href="#morbi-eu-congue"><p>Morbi Eu Congue</p></a></li>
       </ul>
     </li>
     <li>
-      <a href="#praesent-in-eros">Praesent In Eros</a>
+      <a href="#praesent-in-eros"><p>Praesent In Eros</p></a>
     </li>
     <li>
-      <a href="#etiam-metus-augue">Etiam Metus Augue</a>
+      <a href="#etiam-metus-augue"><p>Etiam Metus Augue</p></a>
       <ul class="nav nav-stacked">
-        <li><a href="#commodo-urna">Commodo Urna</a></li>
+        <li><a href="#commodo-urna"><p>Commodo Urna</p></a></li>
       </ul>
     </li>
   </ul>
@@ -132,13 +132,13 @@ console.log('test');
 <nav class="workshop-sidebar hidden-print hidden-xs hidden-sm affix">
   <ul id="sidebar" class="nav nav-stacked fixed">
     <li>
-      <a href="#dolor-sit-amet">Dolor Sit Amet</a>
+      <a href="#dolor-sit-amet"><p>Dolor Sit Amet</p></a>
       <ul class="nav nav-stacked">
-        <li><a href="#consectetur-adipiscing-elit">Consectetur Adipiscing Elit</a></li>
+        <li><a href="#consectetur-adipiscing-elit"><p>Consectetur Adipiscing Elit</p></a></li>
       </ul>
     </li>
     <li>
-      <a href="#etiam-metus-augue">Etiam Metus Augue</a>
+      <a href="#etiam-metus-augue"><p>Etiam Metus Augue</p></a>
     </li>
   </ul>
 </nav>
@@ -149,5 +149,29 @@ console.log('test');
 
     assert_equal(expected1, output1)
     assert_equal(expected2, output2)
+  end
+
+  test "it renders Markdown in sidebar links" do
+    input = %(
+## `<marquee>` Cringe 101 is leaking
+
+### `<b>` Please make it stop
+).strip
+
+    expected = %(
+<nav class="workshop-sidebar hidden-print hidden-xs hidden-sm affix">
+  <ul id="sidebar" class="nav nav-stacked fixed">
+    <li>
+      <a href="#marquee-cringe-101-is-leaking"><p><code>&lt;marquee&gt;</code> Cringe 101 is leaking</p></a>
+      <ul class="nav nav-stacked">
+        <li><a href="#b-please-make-it-stop"><p><code>&lt;b&gt;</code> Please make it stop</p></a></li>
+      </ul>
+    </li>
+  </ul>
+</nav>
+).strip
+
+    actual = MarkdownService.new.render_sidebar(input)
+    assert_equal(expected, actual)
   end
 end


### PR DESCRIPTION
This pull request modifies our sidebar renderer to render Markdown in the headings it's including in the sidebar.

Once tests pass, I'm going to merge myself because I'm the only FTE on this project. This closes #42.
